### PR TITLE
Use the root logger

### DIFF
--- a/flask_oidc_ext/__init__.py
+++ b/flask_oidc_ext/__init__.py
@@ -50,7 +50,7 @@ import httplib2
 
 __all__ = ["OpenIDConnect", "MemoryCredentials", "MemoryTokens", "MemoryBadTokens"]
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 def _json_loads(content):


### PR DESCRIPTION
Use the root logger, otherwise Google Cloud logging can't pick up log messages from flask-oidc.